### PR TITLE
Update to the license so GitHub recognizes the BSD-3-Clause underneath

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,3 @@
-License agreement for the cuda-wrapper library
-==============================================
-
 Copyright (C) 2007—2012 Peter Colberg
 Copyright (C) 2012-2016 Felix Höfling
 Copyright (C) 2020      Jaslo Ziska

--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,6 @@ Copyright (C) 2007—2012 Peter Colberg
 Copyright (C) 2012-2016 Felix Höfling
 Copyright (C) 2020      Jaslo Ziska
 Copyright (C) 2015      Nicolas Höft
-All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions


### PR DESCRIPTION
Hello,

I came across this repository and noticed the license not being recognized, so I decided to submit a quick fix, which you will hopefully find useful. If not, that's no problem either -- don't feel obliged to merge any of this. 

Without this PR's changes, the GitHub frontend renders like this:

![image](https://user-images.githubusercontent.com/4558105/156006865-07681cab-f90f-4ca2-b7c9-a8a3a0a31c60.png)

With the changes, it is like that (screenshot of the forked repo hence no stars etc):

![image](https://user-images.githubusercontent.com/4558105/156006984-0479819d-4fbb-4ab2-b0fb-0e151e8dc585.png)

BTW the reason I saw this was because I was doing some work on https://github.com/nlesc-recruit/CUDA-wrappers, trying to get the lay of the land of existing tools that occupy this problem space.

Best regards,
Jurriaan
